### PR TITLE
Feat : Security + Jwt 기능으로 인증, 인가 서비스 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,18 +23,26 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
 	//jwt
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	//For db
 	runtimeOnly 'com.h2database:h2'
+
+	//lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	//Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	//Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 	//Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 }

--- a/src/main/java/com/sparta/onboarding/assignment/auth/AuthController.java
+++ b/src/main/java/com/sparta/onboarding/assignment/auth/AuthController.java
@@ -1,0 +1,78 @@
+package com.sparta.onboarding.assignment.auth;
+
+
+import com.sparta.onboarding.assignment.auth.request.LoginRequest;
+import com.sparta.onboarding.assignment.auth.request.RegisterRequest;
+import com.sparta.onboarding.assignment.auth.response.LoginResponse;
+import com.sparta.onboarding.assignment.auth.response.RegisterResponse;
+import com.sparta.onboarding.assignment.jwt.JwtUtil;
+import com.sparta.onboarding.assignment.jwt.TokenDto;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+    private final AuthService authService;
+    private final JwtUtil jwtUtil;
+
+    @PostMapping("/signup")
+    public ResponseEntity<RegisterResponse> register(
+            @RequestBody @Valid RegisterRequest request) {
+        return ResponseEntity.ok(
+                RegisterResponse.from(authService.register(request.toAuthDto()))
+        );
+    }
+
+    @PostMapping("/sign")
+    public ResponseEntity<LoginResponse> login(
+            @RequestBody @Valid LoginRequest request,
+            HttpServletResponse response
+    ){
+        TokenDto tokenDto = authService.login(request.toAuthDto());
+        // 리프레쉬 토큰 쿠키
+        Cookie refreshTokenCookie = jwtUtil.createCookie(tokenDto.refreshToken());
+        response.addCookie(refreshTokenCookie);
+        return ResponseEntity.ok(
+                new LoginResponse(tokenDto.accessToken())
+        );
+    }
+
+    @GetMapping("/refresh")
+    public ResponseEntity<LoginResponse> refreshToken(
+            HttpServletRequest request,
+            HttpServletResponse response
+            ) {
+        // 쿠키에서 refreshToken 가져오기
+        String refreshToken = getRefreshTokenFromCookies(request);
+
+        if (refreshToken == null || !jwtUtil.validateToken(refreshToken)) {
+            return ResponseEntity.status(401).body(null);  // 유효하지 않거나 없으면 Unauthorized 반환
+        }
+        TokenDto tokenDto = authService.refresh(refreshToken);
+        Cookie refreshTokenCookie = jwtUtil.createCookie(tokenDto.refreshToken());
+        response.addCookie(refreshTokenCookie);
+        return ResponseEntity.ok(new LoginResponse(tokenDto.accessToken()));
+    }
+
+    // 쿠키에서 refreshToken을 찾는 유틸리티 메소드
+    private String getRefreshTokenFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refreshToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/sparta/onboarding/assignment/auth/AuthService.java
+++ b/src/main/java/com/sparta/onboarding/assignment/auth/AuthService.java
@@ -1,0 +1,72 @@
+package com.sparta.onboarding.assignment.auth;
+
+
+import com.sparta.onboarding.assignment.auth.dto.AuthDto;
+import com.sparta.onboarding.assignment.jwt.JwtUtil;
+import com.sparta.onboarding.assignment.jwt.TokenDto;
+import com.sparta.onboarding.assignment.user.RoleType;
+import com.sparta.onboarding.assignment.user.User;
+import com.sparta.onboarding.assignment.user.UserRepository;
+import com.sparta.onboarding.assignment.user.dto.UserDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+
+    @Transactional
+    public UserDto register(AuthDto authDto) {
+        //중복 체크
+        checkDuplicatedUser(authDto.username(), authDto.nickname());
+        //회원가입
+        User user = User.createUser(
+                authDto.username(), passwordEncoder.encode(authDto.password()), authDto.nickname()
+        );
+        return UserDto.from(userRepository.save(user));
+    }
+
+    @Transactional
+    public TokenDto login(AuthDto authDto) {
+        authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(
+                        authDto.username(),
+                        authDto.password()
+                )
+        );
+        User user = userRepository.findByUsername(authDto.username()).orElseThrow(
+                () -> new IllegalArgumentException("User not found with username")
+        );
+        return jwtUtil.generateToken(user);
+    }
+
+    private void checkDuplicatedUser(String username, String nickname) {
+        if (userRepository.existsByUsername(username)){
+            throw new IllegalArgumentException("Duplicated username");
+        }
+        if (userRepository.existsByNickname(nickname)){
+            throw new IllegalArgumentException("Duplicated nickname");
+        }
+    }
+
+    public TokenDto refresh(String refreshToken) {
+        // refreshToken을 통해 새로운 accessToken 발급
+        String username = jwtUtil.extractUsername(refreshToken);
+        User user = userRepository.findByUsername(username).orElseThrow(
+                () -> new IllegalArgumentException("User not found with username")
+        );
+        TokenDto newTokenSet = jwtUtil.generateToken(user);
+
+        return newTokenSet;
+    }
+}

--- a/src/main/java/com/sparta/onboarding/assignment/auth/dto/AuthDto.java
+++ b/src/main/java/com/sparta/onboarding/assignment/auth/dto/AuthDto.java
@@ -1,0 +1,11 @@
+package com.sparta.onboarding.assignment.auth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AuthDto(
+        String username,
+        String nickname,
+        String password
+) {
+}

--- a/src/main/java/com/sparta/onboarding/assignment/auth/request/LoginRequest.java
+++ b/src/main/java/com/sparta/onboarding/assignment/auth/request/LoginRequest.java
@@ -1,0 +1,19 @@
+package com.sparta.onboarding.assignment.auth.request;
+
+import com.sparta.onboarding.assignment.auth.dto.AuthDto;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "사용자 이름은 비어있을 수 없습니다.")
+        String username,
+        @NotBlank(message = "사용자 비밀번호는 비어있을 수 없습니다.")
+        String password
+) {
+
+        public AuthDto toAuthDto() {
+                return AuthDto.builder()
+                        .username(username)
+                        .password(password)
+                        .build();
+        }
+}

--- a/src/main/java/com/sparta/onboarding/assignment/auth/request/RegisterRequest.java
+++ b/src/main/java/com/sparta/onboarding/assignment/auth/request/RegisterRequest.java
@@ -1,0 +1,22 @@
+package com.sparta.onboarding.assignment.auth.request;
+
+import com.sparta.onboarding.assignment.auth.dto.AuthDto;
+import jakarta.validation.constraints.NotBlank;
+
+public record RegisterRequest(
+        @NotBlank(message = "사용자 이름은 비어있을 수 없습니다.")
+        String username,
+        @NotBlank(message = "사용자 닉네임은 비어있을 수 없습니다.")
+        String nickname,
+        @NotBlank(message = "사용자 비밀번호는 비어있을 수 없습니다.")
+        String password
+) {
+
+    public AuthDto toAuthDto(){
+        return AuthDto.builder()
+                .username(username)
+                .nickname(nickname)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/onboarding/assignment/auth/response/LoginResponse.java
+++ b/src/main/java/com/sparta/onboarding/assignment/auth/response/LoginResponse.java
@@ -1,0 +1,6 @@
+package com.sparta.onboarding.assignment.auth.response;
+
+public record LoginResponse(
+        String token
+) {
+}

--- a/src/main/java/com/sparta/onboarding/assignment/auth/response/RegisterResponse.java
+++ b/src/main/java/com/sparta/onboarding/assignment/auth/response/RegisterResponse.java
@@ -1,0 +1,27 @@
+package com.sparta.onboarding.assignment.auth.response;
+
+import com.sparta.onboarding.assignment.user.dto.UserDto;
+import lombok.Builder;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Builder
+public record RegisterResponse(
+        String username,
+        String nickname,
+        Set<AuthorityResponse> authorities
+) {
+    public record AuthorityResponse(String authorityName){}
+
+    public static RegisterResponse from(UserDto dto) {
+        return RegisterResponse.builder()
+                .username(dto.username())
+                .nickname(dto.nickname())
+                .authorities(dto.roleTypes().stream()
+                        .map(auth -> new AuthorityResponse(auth.getRoleName()))
+                        .collect(Collectors.toUnmodifiableSet())
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/onboarding/assignment/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/onboarding/assignment/config/SecurityConfig.java
@@ -1,0 +1,101 @@
+package com.sparta.onboarding.assignment.config;
+
+import com.sparta.onboarding.assignment.config.handler.CustomAccessDeniedHandler;
+import com.sparta.onboarding.assignment.config.handler.CustomAuthenticationEntryPoint;
+import com.sparta.onboarding.assignment.jwt.JwtAuthenticationFilter;
+import com.sparta.onboarding.assignment.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final UserRepository userRepository;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(
+            HttpSecurity http,
+            JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+        http
+                .formLogin(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(
+                        (sessionManagement) -> sessionManagement
+                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .exceptionHandling(securityExceptionHandler->
+                        securityExceptionHandler
+                                .accessDeniedHandler(accessDeniedHandler)
+                                .authenticationEntryPoint(authenticationEntryPoint))
+                .addFilterBefore(
+                        jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        ;
+        // For API request
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers(HttpMethod.POST, "signup").permitAll()
+                        .requestMatchers(HttpMethod.POST, "sign").permitAll()
+                        .requestMatchers(HttpMethod.GET, "refresh").permitAll()
+                )
+        ;
+        // For Swagger ,etc.
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("v3/api-docs/**").permitAll()
+                        .requestMatchers("swagger-resources").permitAll()
+                        .requestMatchers("swagger-resources/**").permitAll()
+                        .requestMatchers("configuration/ui").permitAll()
+                        .requestMatchers("configuration/security").permitAll()
+                        .requestMatchers("swagger-ui/**").permitAll()
+                        .requestMatchers("webjars/**").permitAll()
+                        .requestMatchers("swagger-ui.html").permitAll()
+                )
+        ;
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(){
+        return username -> userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService());
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/sparta/onboarding/assignment/config/SwaggerConfig.java
+++ b/src/main/java/com/sparta/onboarding/assignment/config/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package com.sparta.onboarding.assignment.config;
+
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "Sparta Onboarding - Security, Jwt", version = "1.0.0", description = "Jwt, Security 를 활용한 인증, 인가 테스트")
+)
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearer-jwt", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"))
+                .addServersItem(new Server().url("http://localhost:8080"));
+    }
+}

--- a/src/main/java/com/sparta/onboarding/assignment/config/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/sparta/onboarding/assignment/config/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package com.sparta.onboarding.assignment.config.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.onboarding.assignment.exception.ApiErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException ex) throws IOException{
+        var errorResponse = ApiErrorResponse.builder()
+                .statusCode(HttpServletResponse.SC_FORBIDDEN)
+                .message(ex.getMessage())
+                .localDateTime(LocalDateTime.now())
+                .build();
+
+        // 응답 상태 코드 설정
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        // 응답 메시지 설정
+        objectMapper.writeValue(response.getWriter(),errorResponse);
+    }
+}

--- a/src/main/java/com/sparta/onboarding/assignment/config/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/sparta/onboarding/assignment/config/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,46 @@
+package com.sparta.onboarding.assignment.config.handler;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.onboarding.assignment.exception.ApiErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException ex
+    ) throws IOException, ServletException {
+
+        log.error("[인증 오류] - 내용 : {}",ex.getMessage());
+
+        var errorResponse = ApiErrorResponse.builder()
+                .statusCode(HttpServletResponse.SC_UNAUTHORIZED)
+                .message(ex.getMessage())
+                .localDateTime(LocalDateTime.now())
+                .build();
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+}

--- a/src/main/java/com/sparta/onboarding/assignment/exception/ApiErrorResponse.java
+++ b/src/main/java/com/sparta/onboarding/assignment/exception/ApiErrorResponse.java
@@ -1,0 +1,27 @@
+package com.sparta.onboarding.assignment.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@Builder
+@Getter
+public class ApiErrorResponse {
+
+    private int statusCode;
+    private String errorCode;
+    private String message;
+    private Map<String, String> validation;
+    private LocalDateTime localDateTime;
+
+    //validation error 시 사용
+    public void addValidation(String field, String errorMessage) {
+        if (validation == null) {
+            validation = new HashMap<>();
+        }
+        this.validation.put(field, errorMessage);
+    }
+}

--- a/src/main/java/com/sparta/onboarding/assignment/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/onboarding/assignment/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,63 @@
+package com.sparta.onboarding.assignment.jwt;
+
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailService;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        final String jwt;
+        final String username;
+
+        // jwt 추출
+        jwt = jwtUtil.resolveToken(request);
+        if (jwt == null){
+            filterChain.doFilter(request, response);
+            return;
+        }
+        // 토큰 추출
+        username =  jwtUtil.extractUsername(jwt);
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = this.userDetailService.loadUserByUsername(username);
+            //인증
+            if (jwtUtil.validateToken(jwt)) {
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities()
+                );
+                authToken.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request)
+                );
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+        filterChain.doFilter(request,response);
+    }
+}

--- a/src/main/java/com/sparta/onboarding/assignment/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/onboarding/assignment/jwt/JwtUtil.java
@@ -1,0 +1,136 @@
+package com.sparta.onboarding.assignment.jwt;
+
+import com.sparta.onboarding.assignment.user.User;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtUtil {
+    // Header KEY 값
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    // Token 식별자
+    public static final String GRANT_TYPE = "Bearer";
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpiration;
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    public TokenDto generateToken(User user) {
+
+        //accessToken 생성
+        String accessToken = Jwts.builder()
+                .setSubject(user.getUsername())
+                .claim("roles", user.getRoleTypes())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
+                .signWith(getSignInKey(), SignatureAlgorithm.HS256)
+                .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setSubject(user.getUsername())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))
+                .signWith(getSignInKey(), SignatureAlgorithm.HS256)
+                .compact();
+
+        return TokenDto.builder()
+                .grantType(GRANT_TYPE)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public Cookie createCookie(String refreshToken) {
+        String cookieName = "refreshToken";
+        Cookie cookie = new Cookie(cookieName, refreshToken);
+        // 쿠키 속성 설정
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(60 * 60 * 24);
+        return cookie;
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (authorizationHeader != null && authorizationHeader.startsWith(GRANT_TYPE+" "))
+            return authorizationHeader.substring(GRANT_TYPE.length()+1);
+
+        return null;
+    }
+
+    public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = extractAllClaims(token);
+        return claimsResolver.apply(claims);
+    }
+
+    public String extractUsername(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    private Date extractExpiration(String token) {
+        return extractClaim(token, Claims::getExpiration);
+    }
+
+    public boolean isTokenExpired(String token) {
+        try {
+            return extractExpiration(token).before(new Date());
+        } catch (ExpiredJwtException e) {
+            return true; // 토큰이 만료되었을 때 true 반환
+        }
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(getSignInKey()).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException | io.jsonwebtoken.security.SignatureException e) {
+
+        } catch (ExpiredJwtException e) {
+
+        } catch (UnsupportedJwtException e) {
+
+        } catch (IllegalArgumentException e) {
+
+        }
+        return false;
+    }
+
+
+    private Claims extractAllClaims(String token) {
+        return Jwts
+                .parserBuilder()
+                .setSigningKey(getSignInKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private SecretKey getSignInKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+}

--- a/src/main/java/com/sparta/onboarding/assignment/jwt/TokenDto.java
+++ b/src/main/java/com/sparta/onboarding/assignment/jwt/TokenDto.java
@@ -1,0 +1,11 @@
+package com.sparta.onboarding.assignment.jwt;
+
+import lombok.Builder;
+
+@Builder
+public record TokenDto(
+        String grantType,
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/sparta/onboarding/assignment/user/RoleType.java
+++ b/src/main/java/com/sparta/onboarding/assignment/user/RoleType.java
@@ -1,0 +1,13 @@
+package com.sparta.onboarding.assignment.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum RoleType {
+    USER("ROLE_USER"),  // 사용자 권한
+    ADMIN("ROLE_ADMIN");  // 관리자 권한
+
+    private final String roleName;
+}

--- a/src/main/java/com/sparta/onboarding/assignment/user/RoleTypesConverter.java
+++ b/src/main/java/com/sparta/onboarding/assignment/user/RoleTypesConverter.java
@@ -1,0 +1,25 @@
+package com.sparta.onboarding.assignment.user;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Converter()
+public class RoleTypesConverter implements AttributeConverter<Set<RoleType>, String> {
+
+    private static final String DELIMITER = ",";
+
+    @Override
+    public String convertToDatabaseColumn(Set<RoleType> attribute) {
+        return attribute.stream().map(RoleType::name).sorted().collect(Collectors.joining(DELIMITER));
+    }
+
+    @Override
+    public Set<RoleType> convertToEntityAttribute(String dbData) {
+        return Arrays.stream(dbData.split(DELIMITER)).map(RoleType::valueOf).collect(Collectors.toSet());
+    }
+}
+

--- a/src/main/java/com/sparta/onboarding/assignment/user/User.java
+++ b/src/main/java/com/sparta/onboarding/assignment/user/User.java
@@ -1,0 +1,84 @@
+package com.sparta.onboarding.assignment.user;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(name = "p_user")
+public class User implements UserDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false, unique = true)
+    private String username;
+    @Column(nullable = false, unique = true)
+    private String nickname;
+    @Column(nullable = false)
+    private String password;
+
+    @Convert(converter = RoleTypesConverter.class)
+    private Set<RoleType> roleTypes = new LinkedHashSet<>();
+
+
+    public static User createUser(String username, String password, String nickname) {
+        return User.builder()
+                .username(username)
+                .password(password)
+                .nickname(nickname)
+                .roleTypes(Set.of(RoleType.USER))
+                .build();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return roleTypes.stream()
+                .map(RoleType::getRoleName)
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/sparta/onboarding/assignment/user/UserRepository.java
+++ b/src/main/java/com/sparta/onboarding/assignment/user/UserRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.onboarding.assignment.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+    Boolean existsByUsername(String username);
+    Boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/sparta/onboarding/assignment/user/dto/UserDto.java
+++ b/src/main/java/com/sparta/onboarding/assignment/user/dto/UserDto.java
@@ -1,0 +1,27 @@
+package com.sparta.onboarding.assignment.user.dto;
+
+import com.sparta.onboarding.assignment.user.RoleType;
+import com.sparta.onboarding.assignment.user.User;
+import lombok.Builder;
+
+import java.util.Set;
+
+@Builder
+public record UserDto(
+        Long id,
+        String username,
+        String nickname,
+        String password,
+        Set<RoleType> roleTypes
+) {
+
+    public static UserDto from(User entity){
+        return UserDto.builder()
+                .id(entity.getId())
+                .username(entity.getUsername())
+                .nickname(entity.getNickname())
+                .password(entity.getPassword())
+                .roleTypes(entity.getRoleTypes())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,8 +22,7 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
     show-sql: true
 jwt:
-  access-key: ${JWT_ACCESS_KEY}
-  refresh-key: ${JWT_REFRESH_KEY}
+  secret-key: ${JWT_SECRET_KEY}
   access-token-expiration: ${ACCESS_TOKEN_EXPIRATION}
   refresh-token-expiration: ${REFRESH_TOKEN_EXPIRATION}
 
@@ -38,3 +37,6 @@ springdoc:
     path: /v3/api-docs
   swagger-ui:
     path: /swagger-ui.html
+  enable-spring-security: true
+  default-consumes-media-type: application/json;charset=UTF-8 # ?? ?? Data Type
+  default-produces-media-type: application/json;charset=UTF-8 # ?? ?? Data Type

--- a/src/test/java/com/sparta/onboarding/assignment/auth/AuthControllerTest.java
+++ b/src/test/java/com/sparta/onboarding/assignment/auth/AuthControllerTest.java
@@ -1,0 +1,135 @@
+package com.sparta.onboarding.assignment.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.onboarding.assignment.auth.request.LoginRequest;
+import com.sparta.onboarding.assignment.auth.request.RegisterRequest;
+import com.sparta.onboarding.assignment.auth.response.RegisterResponse;
+import com.sparta.onboarding.assignment.jwt.JwtUtil;
+import com.sparta.onboarding.assignment.jwt.TokenDto;
+import com.sparta.onboarding.assignment.security.TestSecurityConfig;
+import com.sparta.onboarding.assignment.user.RoleType;
+import com.sparta.onboarding.assignment.user.dto.UserDto;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Set;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@Import({TestSecurityConfig.class})
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @MockBean
+    private AuthService authService;
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @DisplayName("회원가입 성공")
+    @Test
+    void testRegister() throws Exception {
+        // Given
+        RegisterRequest request = new RegisterRequest("testUsername", "testNickname", "testPassword");
+        UserDto user = createUserDto();
+        RegisterResponse response = RegisterResponse.from(user);
+
+        when(authService.register(any())).thenReturn(user);
+
+        // When & Then
+        mockMvc.perform(post("/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value(response.username()))
+                .andExpect(jsonPath("$.nickname").value(response.nickname()))
+                .andExpect(jsonPath("$.authorities").isArray())
+                .andExpect(jsonPath("$.authorities[0].authorityName").value("ROLE_USER"));
+    }
+
+    @DisplayName("로그인 성공")
+    @Test
+    void testLogin() throws Exception {
+        // Given
+        LoginRequest loginRequest = new LoginRequest("testUser", "testPassword");
+        String mockAccessToken = "mockAccessToken";
+        String mockRefreshToken = "mockRefreshToken";
+
+        TokenDto tokenDto = TokenDto.builder()
+                .grantType("Bearer")
+                .accessToken(mockAccessToken)
+                .refreshToken(mockRefreshToken)
+                .build();
+
+        when(authService.login(any())).thenReturn(tokenDto);
+        when(jwtUtil.createCookie(any())).thenReturn(new Cookie("refreshToken",mockRefreshToken));
+
+        // When & Then
+        mockMvc.perform(post("/sign")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").value("mockAccessToken"));
+    }
+
+    private UserDto createUserDto(){
+        return UserDto.builder()
+                .id(1L)
+                .username("testUsername")
+                .nickname("testNickname")
+                .password("testPassword")
+                .roleTypes(Set.of(RoleType.USER))
+                .build();
+    }
+
+    @DisplayName("리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급")
+    @Test
+    void testRefreshToken() throws Exception {
+        // Given
+        String refreshToken = "valid-refresh-token";
+        String newAccessToken = "new-access-token";
+        TokenDto tokenDto = TokenDto.builder()
+                .grantType("Bearer")
+                .accessToken(newAccessToken)
+                .refreshToken(refreshToken)
+                .build();
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        Cookie refreshCookie = new Cookie("refreshToken", refreshToken);
+
+        // Mocking
+        when(jwtUtil.validateToken(refreshToken)).thenReturn(true);
+        when(authService.refresh(refreshToken)).thenReturn(tokenDto);
+        when(jwtUtil.createCookie(any())).thenReturn(refreshCookie);
+
+
+        // When & Then
+        mockMvc.perform(get("/refresh")
+                        .requestAttr("request", request)
+                        .cookie(refreshCookie)) // 쿠키 설정
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").value(newAccessToken));
+
+        verify(jwtUtil).validateToken(refreshToken); // validateToken 호출 검증
+        verify(authService).refresh(refreshToken); // refresh 호출 검증
+    }
+}

--- a/src/test/java/com/sparta/onboarding/assignment/jwt/JwtUtilTest.java
+++ b/src/test/java/com/sparta/onboarding/assignment/jwt/JwtUtilTest.java
@@ -1,0 +1,101 @@
+package com.sparta.onboarding.assignment.jwt;
+
+import com.sparta.onboarding.assignment.user.RoleType;
+import com.sparta.onboarding.assignment.user.User;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class JwtUtilTest {
+
+    private JwtUtil jwtUtil;
+    private User user;
+    private String secretKey = "adklfjakldfjklj1pjklajfdkljakldfjaklj2103jkfdljalkfdadf";
+    private long accessTokenExpiration = 3600000;
+    private long refreshTokenExpiration = 86400000;
+
+
+    @BeforeAll
+    public void setUp() {
+        jwtUtil = new JwtUtil();
+        //jwtUtil 의 Value 대신 값 삽입
+        ReflectionTestUtils.setField(jwtUtil, "secretKey", secretKey);
+        ReflectionTestUtils.setField(jwtUtil, "accessTokenExpiration", accessTokenExpiration);
+        ReflectionTestUtils.setField(jwtUtil, "refreshTokenExpiration", refreshTokenExpiration);
+        user = User.builder()
+                .id(1L).username("testUsername").nickname("testNickname").password("testPassword")
+                .roleTypes(Set.of(RoleType.USER)).build();
+    }
+
+    @DisplayName("토큰 생성 테스트")
+    @Test
+    public void generateTokenTest(){
+        TokenDto tokenDto = jwtUtil.generateToken(user);
+
+        System.out.println("AccessToken : " + tokenDto.accessToken());
+        System.out.println("RefreshToken: " + tokenDto.refreshToken());
+
+        assertNotNull(tokenDto.accessToken());
+        assertNotNull(tokenDto.refreshToken());
+        assertEquals(JwtUtil.GRANT_TYPE, tokenDto.grantType());
+
+        // 토큰의 유효성 검사
+        assertTrue(jwtUtil.validateToken(tokenDto.accessToken()));
+        assertTrue(jwtUtil.validateToken(tokenDto.refreshToken()));
+    }
+
+    @DisplayName("잘못된 토큰 유효성 테스트")
+    @Test
+    public void testValidateToken_withInvalidToken() {
+        String invalidToken = "invalid.token.value";
+
+        boolean isValid = jwtUtil.validateToken(invalidToken);
+
+        assertFalse(isValid, "Token should be invalid");
+    }
+
+    @DisplayName("만료 시간 지난 토큰 검증 -> True 반환")
+    @Test
+    public void testIsTokenExpired_withExpiredToken() {
+        // 만료 시간이 매우 짧은 토큰을 생성하여 만료 상태를 테스트
+        Date now = new Date();
+        String expiredToken = Jwts.builder()
+                .setSubject("testUsername")
+                .setExpiration(new Date(System.currentTimeMillis() - 1000)) // 만료된 토큰
+                .signWith(getSignInKey(), SignatureAlgorithm.HS256)
+                .compact();
+
+        boolean isExpired = jwtUtil.isTokenExpired(expiredToken);
+
+        assertTrue(isExpired, "Token should be expired");
+    }
+
+    @DisplayName("토큰에서 유저 이름 추출 테스트")
+    @Test
+    public void testExtractUsername() {
+        String token = jwtUtil.generateToken(user).accessToken();
+
+        String extractedUsername = jwtUtil.extractUsername(token);
+
+        assertEquals("testUsername", extractedUsername, "Extracted username should match user ID");
+    }
+
+    private SecretKey getSignInKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+}

--- a/src/test/java/com/sparta/onboarding/assignment/security/CustomMockSecurityContext.java
+++ b/src/test/java/com/sparta/onboarding/assignment/security/CustomMockSecurityContext.java
@@ -1,0 +1,28 @@
+package com.sparta.onboarding.assignment.security;
+
+import com.sparta.onboarding.assignment.user.RoleType;
+import com.sparta.onboarding.assignment.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.Set;
+
+@RequiredArgsConstructor
+public class CustomMockSecurityContext implements WithSecurityContextFactory<WithCustomMockUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
+
+        var principal = User.builder()
+                .username(annotation.username()).nickname(annotation.nickname()).password(annotation.password())
+                .roleTypes(Set.of(RoleType.USER))
+                .build();
+        var authToken = new UsernamePasswordAuthenticationToken(principal, annotation.password(), principal.getAuthorities());
+        var context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authToken);
+        return context;
+    }
+}

--- a/src/test/java/com/sparta/onboarding/assignment/security/TestSecurityConfig.java
+++ b/src/test/java/com/sparta/onboarding/assignment/security/TestSecurityConfig.java
@@ -1,0 +1,44 @@
+package com.sparta.onboarding.assignment.security;
+
+
+import com.sparta.onboarding.assignment.jwt.JwtAuthenticationFilter;
+import com.sparta.onboarding.assignment.jwt.JwtUtil;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@TestConfiguration
+@EnableWebSecurity
+@Import({JwtAuthenticationFilter.class})
+public class TestSecurityConfig {
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+        http
+                .formLogin(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(
+                        (sessionManagement) -> sessionManagement
+                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(auth -> {
+                    auth
+                            .requestMatchers(HttpMethod.POST, "signup").permitAll()
+                            .requestMatchers(HttpMethod.POST, "sign").permitAll()
+                            .requestMatchers(HttpMethod.GET, "refresh").permitAll();
+                })
+
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/src/test/java/com/sparta/onboarding/assignment/security/WithCustomMockUser.java
+++ b/src/test/java/com/sparta/onboarding/assignment/security/WithCustomMockUser.java
@@ -1,0 +1,15 @@
+package com.sparta.onboarding.assignment.security;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = CustomMockSecurityContext.class)
+public @interface WithCustomMockUser {
+
+    String nickname() default "testnickname";
+    String username() default "testusername";
+    String password() default "testpassword";
+}


### PR DESCRIPTION
## Feat 
- Login
- Register
- Refresh authentitcation with refreshToken

### Requirement feature
- `JwtUtil` : Jwt 생성 및 검증
- `JwtAuthenticationFilter` :  토큰을 통한 요청 인증
- `SecurityConfig` : Web 요청에 대한 보안 설정
- `User`
  - **UserDetails**  를 구현한 엔티티 객체로 작성
  - `RoleTypesConverter` 를 통해 RoleType enum 리스트를 DB 저장과 객체로 다룰 시 편리하게 사용
 
### Unit Test
- Jwt 생성 및 검증 테스트
- AuthController mock test